### PR TITLE
Fix multiplatform runtime images

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,10 +7,8 @@ import (
 	"dolittle.io/contracts-compatibility/registries/npm"
 	"dolittle.io/contracts-compatibility/registries/nuget"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
-	"github.com/coreos/go-semver/semver"
 	"os"
 )
 
@@ -65,14 +63,10 @@ func createGraph(username, password string) (*artifacts.Graph, error) {
 		return nil, fmt.Errorf("could not get Docker Hub authentication token, %w", err)
 	}
 
-	resolver := docker.NewDependencyResolverFor(token, "dolittle/runtime", dotnet.NewDepsResolverFor("Dolittle.Runtime.Contracts"), "app/Dolittle.Runtime.Server.deps.json", "app/Server.deps.json")
-	resolver.ResolveDependencyForVersion(semver.New("8.4.1"))
-	return nil, errors.New("HELLO")
-
 	graph := artifacts.CreateGraphFor(
 		artifacts.NewReleaseListResolver(
 			docker.NewReleaseListerFor(token, "dolittle/runtime"),
-			docker.NewDependencyResolverFor(token, "dolittle/runtime", dotnet.NewDepsResolverFor("Dolittle.Runtime.Contracts"), "app/Dolittle.Runtime.Server.deps.json", "app/Server.deps.json"),
+			docker.NewDependencyResolverFor(token, "dolittle/runtime", dotnet.NewDepsResolverFor("Dolittle.Contracts"), "app/Dolittle.Runtime.Server.deps.json", "app/Server.deps.json"),
 		),
 		map[string]*artifacts.ReleaseListResolver{
 			"DotNET": artifacts.NewReleaseListResolver(

--- a/registries/docker/resolver.go
+++ b/registries/docker/resolver.go
@@ -61,7 +61,6 @@ func (resolver *DependencyResolver) getDockerImageLayers(version *semver.Version
 		return nil, fmt.Errorf("could not create Docker manifest request: %w", err)
 	}
 	request.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
-	request.Header.Add("Accept", "application/vnd.docker.distribution.manifest.list.v2+json")
 
 	info := dockerManifest{}
 	if err := http.DoJSON(request, &info); err != nil {


### PR DESCRIPTION
## Summary

Makes the tool work with Runtimes after version `8.0.0`. There were two changes outside the tool that made it stop working for newer versions.

### Added

- The option of passing in a username and password/PAT for Docker Hub. This is useful to avoid rate-limiting when debugging the tool locally.

### Fixed

- For the Runtime image, the tool now looks for a dependency to `Dolittle.Contracts` instead of `Dolittle.Runtime.Contracts`. We merged these to packages into the former recently, so now we need to rely on this one. This still works for older versions since we published them together previously.
- For the Runtime image, the tool no longer accepts "fat manifests" from the Docker Hub API. Since we started publishing "multi-platform images", these "fat manifest" files started returning a different format we didn't support. With this change, Docker Hub returns the `Linux amd64` manifest by default, thereby fixing the problem for now.